### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+dist/

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,5 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte()],
-  base: './'
+  base: '/photo_gallery_europe_2025/'
 });


### PR DESCRIPTION
## Summary
- update vite config with explicit base path for GitHub Pages
- ignore generated `dist` output

## Testing
- `npm run build`
- `npm run preview` *(fails: no server due to container limits)*

------
https://chatgpt.com/codex/tasks/task_e_6864681ff4e88328a75d30b2068ff074